### PR TITLE
[Swift Bindings] Implement Swift native handle as `SafeHandle`

### DIFF
--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
@@ -654,7 +654,7 @@ namespace BindingsGeneration
             }
             else
             {
-                csWriter.WriteLine("var self = new SwiftSelf((void*)_payload);");
+                csWriter.WriteLine("var self = new SwiftSelf((void*)_payload.Handle);");
             }
 
             csWriter.WriteLine();
@@ -745,8 +745,8 @@ namespace BindingsGeneration
             }
 
             var text = $$"""
-            _payload = (SwiftHandle)NativeMemory.Alloc(_payloadSize);
-            var swiftIndirectResult = new SwiftIndirectResult((void*)_payload);
+            _payload = new SwiftHandle((IntPtr)NativeMemory.Alloc(_payloadSize));
+            var swiftIndirectResult = new SwiftIndirectResult((void*)_payload.Handle);
             """;
 
             csWriter.WriteLines(text);
@@ -767,7 +767,7 @@ namespace BindingsGeneration
 
             var text = $$"""
             var returnMetadata = TypeMetadata.GetTypeMetadataOrThrow<{{_wrapperSignature.ReturnType}}>();
-            var payload = (SwiftHandle)NativeMemory.Alloc(returnMetadata.Size);
+            var payload = (IntPtr)NativeMemory.Alloc(returnMetadata.Size);
             var swiftIndirectResult = new SwiftIndirectResult((void*)payload);
             """;
 
@@ -785,7 +785,7 @@ namespace BindingsGeneration
                 if (_env.BoundGenericsHandler.RequiresBoundGenericMarshalling(argumentDecl))
                 {
                     var bufferName = NameProvider.GetBoundGenericBufferName(argumentDecl.Name);
-                    csWriter.WriteLine($"var {bufferName} = {argumentDecl.Name}.Payload;");
+                    csWriter.WriteLine($"var {bufferName} = {argumentDecl.Name}.Payload.Handle;");
                 }
             }
         }
@@ -908,7 +908,7 @@ namespace BindingsGeneration
 
             if (_env.BoundGenericsHandler.RequiresBoundGenericMarshalling(returnArg))
             {
-                csWriter.WriteLine($"return SwiftMarshal.MarshalFromSwift<{_env.BoundGenericsHandler.TranslateBoundGenericTypeToCSharp(returnArg)}>((SwiftHandle)new IntPtr(&result));");
+                csWriter.WriteLine($"return SwiftMarshal.MarshalFromSwift<{_env.BoundGenericsHandler.TranslateBoundGenericTypeToCSharp(returnArg)}>(result);");
                 return;
             }
 
@@ -919,7 +919,7 @@ namespace BindingsGeneration
                 {
                     csWriter.WriteLine($$"""
                         unsafe {
-                            return SwiftMarshal.MarshalFromSwift<{{_wrapperSignature.ReturnType}}>((SwiftHandle)new IntPtr(&result));
+                            return SwiftMarshal.MarshalFromSwift<{{_wrapperSignature.ReturnType}}>(new IntPtr(&result));
                         }
                         """);
                     return;
@@ -928,7 +928,7 @@ namespace BindingsGeneration
 
             if (_requiresIndirectResult)
             {
-                csWriter.WriteLine($"return SwiftMarshal.MarshalFromSwift<{_wrapperSignature.ReturnType}>((SwiftHandle)swiftIndirectResult.Value);");
+                csWriter.WriteLine($"return SwiftMarshal.MarshalFromSwift<{_wrapperSignature.ReturnType}>(new IntPtr(swiftIndirectResult.Value));");
                 return;
             }
 
@@ -997,6 +997,8 @@ namespace BindingsGeneration
             var voidReturn = returnType.SwiftTypeSpec.IsEmptyTuple;
             var requiresInitWithCopy = !voidReturn && (!MarshallingHelpers.IsTypeFrozen(returnTypeRecord) || _env.BoundGenericsHandler.IsBoundGeneric(returnType));
 
+            var marshallFromSwiftArgument = _pInvokeSignature.ReturnType == "IntPtr" ? "rawResult" : "new IntPtr(&rawResult)";
+
             var copyExpression = $$"""
                 var metadata = SwiftObjectHelper<{{_wrapperSignature.ReturnType}}>.GetTypeMetadata();
                 byte* payload = stackalloc byte[(int)metadata.Size];
@@ -1011,7 +1013,7 @@ namespace BindingsGeneration
                             GCHandle handle = GCHandle.FromIntPtr(task);
                             try
                             {
-                                {{(voidReturn ? "" : $"var result = SwiftMarshal.MarshalFromSwift<{_wrapperSignature.ReturnType}>((SwiftHandle)new IntPtr(&rawResult));")}}
+                                {{(voidReturn ? "" : $"var result = SwiftMarshal.MarshalFromSwift<{_wrapperSignature.ReturnType}>({marshallFromSwiftArgument});")}}
                                 {{(requiresInitWithCopy ? copyExpression : "")}}
                                 if (handle.Target is TaskCompletionSource{{(voidReturn ? "" : $"<{_wrapperSignature.ReturnType}>")}} tcs)
                                 {

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
@@ -341,7 +341,7 @@ namespace BindingsGeneration
                 {
                     var metadata = SwiftObjectHelper<{{structDecl.Name}}>.GetTypeMetadata();
                     unsafe {
-                        metadata.ValueWitnessTable->Destroy((void *)_payload, metadata);
+                        metadata.ValueWitnessTable->Destroy((void *)_payload.Handle, metadata);
                     }
                     _payload = SwiftHandle.Zero;
                 }
@@ -524,7 +524,8 @@ namespace BindingsGeneration
                 var text = $$"""
                 static unsafe ISwiftObject ISwiftObject.NewFromPayload(SwiftHandle handle)
                 {
-                    return new {{_structDecl.Name}} { _payload = *(Buffer*)handle };
+                    return new {{_structDecl.Name}} { _payload = *(Buffer*)handle.Handle };
+                    // TODO: Store handle for reference counting
                 }
 
                 private {{_structDecl.Name}} ()
@@ -540,7 +541,7 @@ namespace BindingsGeneration
                 var text = $$"""
                 static ISwiftObject ISwiftObject.NewFromPayload(SwiftHandle handle)
                 {
-                    return *({{_structDecl.Name}}*)handle;
+                    return *({{_structDecl.Name}}*)handle.Handle;
                 }
                 """;
 
@@ -623,7 +624,7 @@ namespace BindingsGeneration
             {
                 var metadata = SwiftObjectHelper<{{_structDecl.Name}}>.GetTypeMetadata();
                 unsafe {
-                    metadata.ValueWitnessTable->InitializeWithCopy((void *)swiftDest, (void *)_payload, metadata);
+                    metadata.ValueWitnessTable->InitializeWithCopy((void *)swiftDest, (void *)_payload.Handle, metadata);
                 }
                 return swiftDest;
             }

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/CryptoKit/CryptoKit.cs
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/CryptoKit/CryptoKit.cs
@@ -30,17 +30,17 @@ namespace BindingsGeneration.FunctionalTests
             {
                 if (!_disposed)
                 {
-                    NativeMemory.Free((void*)_payload);
-                    _payload = SwiftHandle.Zero;
-                    _disposed = true;
-                    GC.SuppressFinalize(this);
+                    // NativeMemory.Free((void*)_payload);
+                    // _payload = SwiftHandle.Zero;
+                    // _disposed = true;
+                    // GC.SuppressFinalize(this);
                 }
             }
 
             ~Nonce()
             {
-                NativeMemory.Free((void*)_payload);
-                _payload = SwiftHandle.Zero;
+                // NativeMemory.Free((void*)_payload);
+                // _payload = SwiftHandle.Zero;
             }
 
             public static nuint PayloadSize => _payloadSize;
@@ -68,7 +68,7 @@ namespace BindingsGeneration.FunctionalTests
                 var metadata = SwiftObjectHelper<Nonce>.GetTypeMetadata();
                 unsafe
                 {
-                    metadata.ValueWitnessTable->InitializeWithCopy((void*)swiftDest, (void*)_payload, metadata);
+                    metadata.ValueWitnessTable->InitializeWithCopy((void*)swiftDest, (void*)_payload.Handle, metadata);
                 }
                 return swiftDest;
             }
@@ -94,8 +94,8 @@ namespace BindingsGeneration.FunctionalTests
 
             public Nonce(Data data)
             {
-                _payload = (SwiftHandle)NativeMemory.Alloc(PayloadSize);
-                SwiftIndirectResult swiftIndirectResult = new SwiftIndirectResult((void*)_payload);
+                _payload = new SwiftHandle((IntPtr)NativeMemory.Alloc(PayloadSize));
+                SwiftIndirectResult swiftIndirectResult = new SwiftIndirectResult((void*)_payload.Handle);
 
                 TypeMetadata metadata = SwiftObjectHelper<Data>.GetTypeMetadata();
                 ProtocolWitnessTable witnessTable = ProtocolWitnessTable.GetOrThrow<Data, ISwiftDataProtocol>();
@@ -104,7 +104,7 @@ namespace BindingsGeneration.FunctionalTests
 
                 if (error.Value != null)
                 {
-                    NativeMemory.Free((void*)_payload);
+                    NativeMemory.Free((void*)_payload.Handle);
                     throw new CryptographicException();
                 }
             }
@@ -237,17 +237,17 @@ namespace BindingsGeneration.FunctionalTests
             {
                 if (!_disposed)
                 {
-                    NativeMemory.Free((void*)_payload);
-                    _payload = SwiftHandle.Zero;
-                    _disposed = true;
-                    GC.SuppressFinalize(this);
+                    // NativeMemory.Free((void*)_payload);
+                    // _payload = SwiftHandle.Zero;
+                    // _disposed = true;
+                    // GC.SuppressFinalize(this);
                 }
             }
 
             ~Nonce()
             {
-                NativeMemory.Free((void*)_payload);
-                _payload = SwiftHandle.Zero;
+                // NativeMemory.Free((void*)_payload);
+                // _payload = SwiftHandle.Zero;
             }
 
             public static nuint PayloadSize => _payloadSize;
@@ -275,7 +275,7 @@ namespace BindingsGeneration.FunctionalTests
                 var metadata = SwiftObjectHelper<Nonce>.GetTypeMetadata();
                 unsafe
                 {
-                    metadata.ValueWitnessTable->InitializeWithCopy((void*)swiftDest, (void*)_payload, metadata);
+                    metadata.ValueWitnessTable->InitializeWithCopy((void*)swiftDest, (void*)_payload.Handle, metadata);
                 }
                 return swiftDest;
             }
@@ -301,8 +301,8 @@ namespace BindingsGeneration.FunctionalTests
 
             public Nonce(Data data)
             {
-                _payload = (SwiftHandle)NativeMemory.Alloc(PayloadSize);
-                SwiftIndirectResult swiftIndirectResult = new SwiftIndirectResult((void*)_payload);
+                _payload = new SwiftHandle((IntPtr)NativeMemory.Alloc(PayloadSize));
+                SwiftIndirectResult swiftIndirectResult = new SwiftIndirectResult((void*)_payload.Handle);
 
                 TypeMetadata metadata = SwiftObjectHelper<Data>.GetTypeMetadata();
                 ProtocolWitnessTable witnessTable = ProtocolWitnessTable.GetOrThrow<Data, ISwiftDataProtocol>();
@@ -311,7 +311,7 @@ namespace BindingsGeneration.FunctionalTests
 
                 if (error.Value != null)
                 {
-                    NativeMemory.Free((void*)_payload);
+                    NativeMemory.Free((void*)_payload.Handle);
                     throw new CryptographicException();
                 }
             }
@@ -334,17 +334,17 @@ namespace BindingsGeneration.FunctionalTests
             {
                 if (!_disposed)
                 {
-                    NativeMemory.Free((void*)_payload);
-                    _payload = SwiftHandle.Zero;
-                    _disposed = true;
-                    GC.SuppressFinalize(this);
+                    // NativeMemory.Free((void*)_payload);
+                    // _payload = SwiftHandle.Zero;
+                    // _disposed = true;
+                    // GC.SuppressFinalize(this);
                 }
             }
 
             ~SealedBox()
             {
-                NativeMemory.Free((void*)_payload);
-                _payload = SwiftHandle.Zero;
+                // NativeMemory.Free((void*)_payload);
+                // _payload = SwiftHandle.Zero;
             }
 
             public static nuint PayloadSize => _payloadSize;
@@ -372,7 +372,7 @@ namespace BindingsGeneration.FunctionalTests
                 var metadata = SwiftObjectHelper<SealedBox>.GetTypeMetadata();
                 unsafe
                 {
-                    metadata.ValueWitnessTable->InitializeWithCopy((void*)swiftDest, (void*)_payload, metadata);
+                    metadata.ValueWitnessTable->InitializeWithCopy((void*)swiftDest, (void*)_payload.Handle, metadata);
                 }
                 return swiftDest;
             }
@@ -398,13 +398,13 @@ namespace BindingsGeneration.FunctionalTests
 
             public SealedBox()
             {
-                _payload = (SwiftHandle)NativeMemory.Alloc(_payloadSize);
+                _payload = new SwiftHandle((IntPtr)NativeMemory.Alloc(_payloadSize));
             }
 
             public SealedBox(AesGcm.Nonce nonce, Data ciphertext, Data tag)
             {
-                _payload = (SwiftHandle)NativeMemory.Alloc(PayloadSize);
-                SwiftIndirectResult swiftIndirectResult = new SwiftIndirectResult((void*)_payload);
+                _payload = new SwiftHandle((IntPtr)NativeMemory.Alloc(PayloadSize));
+                SwiftIndirectResult swiftIndirectResult = new SwiftIndirectResult((void*)_payload.Handle);
 
                 TypeMetadata ciphertextMetadata = SwiftObjectHelper<Data>.GetTypeMetadata();
                 TypeMetadata tagMetadata = SwiftObjectHelper<Data>.GetTypeMetadata();
@@ -424,7 +424,7 @@ namespace BindingsGeneration.FunctionalTests
 
                 if (error.Value != null)
                 {
-                    NativeMemory.Free((void*)_payload);
+                    NativeMemory.Free((void*)_payload.Handle);
                     throw new CryptographicException();
                 }
             }
@@ -434,13 +434,13 @@ namespace BindingsGeneration.FunctionalTests
             public static unsafe extern void PInvoke_init(SwiftIndirectResult result, SwiftHandle nonce, void* ciphertext, void* tag, TypeMetadata ciphertextMetadata, TypeMetadata tagMetadata, ProtocolWitnessTable ciphertextWitnessTable, ProtocolWitnessTable tagWitnessTable, out SwiftError error);
 
 
-            public Data Ciphertext => PInvoke_GetCiphertext(new SwiftSelf((void*)_payload));
+            public Data Ciphertext => PInvoke_GetCiphertext(new SwiftSelf((void*)_payload.Handle));
 
             [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
             [DllImport("/System/Library/Frameworks/CryptoKit.framework/CryptoKit", EntryPoint = "$s9CryptoKit3AESO3GCMO9SealedBoxV10ciphertext10Foundation4DataVvg")]
             public static unsafe extern Data PInvoke_GetCiphertext(SwiftSelf sealedBox);
 
-            public Data Tag => PInvoke_GetTag(new SwiftSelf((void*)_payload));
+            public Data Tag => PInvoke_GetTag(new SwiftSelf((void*)_payload.Handle));
 
             [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
             [DllImport("/System/Library/Frameworks/CryptoKit.framework/CryptoKit", EntryPoint = "$s9CryptoKit3AESO3GCMO9SealedBoxV3tag10Foundation4DataVvg")]
@@ -453,7 +453,7 @@ namespace BindingsGeneration.FunctionalTests
         public static unsafe SealedBox seal<Plaintext, AuthenticateData>(Plaintext plaintext, SymmetricKey key, Nonce nonce, AuthenticateData aad, out SwiftError error) where Plaintext : unmanaged, ISwiftObject where AuthenticateData : unmanaged, ISwiftObject
         {
             AesGcm.SealedBox sealedBox = new AesGcm.SealedBox();
-            SwiftIndirectResult swiftIndirectResult = new SwiftIndirectResult((void*)sealedBox.Payload);
+            SwiftIndirectResult swiftIndirectResult = new SwiftIndirectResult((void*)sealedBox.Payload.Handle);
 
 
             TypeMetadata plaintextMetadata = SwiftObjectHelper<Plaintext>.GetTypeMetadata();
@@ -517,17 +517,17 @@ namespace BindingsGeneration.FunctionalTests
         {
             if (!_disposed)
             {
-                NativeMemory.Free((void*)_payload);
-                _payload = SwiftHandle.Zero;
-                _disposed = true;
-                GC.SuppressFinalize(this);
+                // NativeMemory.Free((void*)_payload);
+                // _payload = SwiftHandle.Zero;
+                // _disposed = true;
+                // GC.SuppressFinalize(this);
             }
         }
 
         ~SymmetricKey()
         {
-            NativeMemory.Free((void*)_payload);
-            _payload = SwiftHandle.Zero;
+            // NativeMemory.Free((void*)_payload);
+            // _payload = SwiftHandle.Zero;
         }
 
         public static nuint PayloadSize => _payloadSize;
@@ -555,7 +555,7 @@ namespace BindingsGeneration.FunctionalTests
             var metadata = SwiftObjectHelper<SymmetricKey>.GetTypeMetadata();
             unsafe
             {
-                metadata.ValueWitnessTable->InitializeWithCopy((void*)swiftDest, (void*)_payload, metadata);
+                metadata.ValueWitnessTable->InitializeWithCopy((void*)swiftDest, (void*)_payload.Handle, metadata);
             }
             return swiftDest;
         }
@@ -581,8 +581,8 @@ namespace BindingsGeneration.FunctionalTests
 
         public SymmetricKey(Data data)
         {
-            _payload = (SwiftHandle)NativeMemory.Alloc(PayloadSize);
-            SwiftIndirectResult swiftIndirectResult = new SwiftIndirectResult((void*)_payload);
+            _payload = new SwiftHandle((IntPtr)NativeMemory.Alloc(PayloadSize));
+            SwiftIndirectResult swiftIndirectResult = new SwiftIndirectResult((void*)_payload.Handle);
 
             TypeMetadata metadata = SwiftObjectHelper<Data>.GetTypeMetadata();
             ProtocolWitnessTable witnessTable = ProtocolWitnessTable.GetOrThrow<Data, ISwiftContiguousBytes>();

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/MemoryTests/MemoryTests.cs
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/MemoryTests/MemoryTests.cs
@@ -55,7 +55,7 @@ namespace BindingsGeneration.FunctionalTests
         {
             Bindings.VType vType = new Bindings.VType();
             GC.SuppressFinalize(vType);
-            IntPtr payload = (IntPtr)vType.Payload;
+            IntPtr payload = (IntPtr)vType.Payload.Handle;
 
             // Check the initial count
             Assert.Equal(1, Arc.RetainCount(payload.At(0)));
@@ -95,7 +95,7 @@ namespace BindingsGeneration.FunctionalTests
         {
             Bindings.VType vType = new Bindings.VType();
             GC.SuppressFinalize(vType);
-            IntPtr payload = (IntPtr)vType.Payload;
+            IntPtr payload = (IntPtr)vType.Payload.Handle;
 
             // Check the initial count
             Assert.Equal(1, Arc.RetainCount(payload.At(0)));
@@ -134,7 +134,7 @@ namespace BindingsGeneration.FunctionalTests
         {
             Bindings.VType vType = new Bindings.VType();
             GC.SuppressFinalize(vType);
-            IntPtr payload = (IntPtr)vType.Payload;
+            IntPtr payload = (IntPtr)vType.Payload.Handle;
 
             // Check the initial count
             Assert.Equal(1, Arc.RetainCount(payload.At(0)));
@@ -197,7 +197,7 @@ namespace BindingsGeneration.FunctionalTests
         {
             Bindings.NestedVType vType = new Bindings.NestedVType();
             GC.SuppressFinalize(vType);
-            IntPtr payload = (IntPtr)vType.Payload;
+            IntPtr payload = (IntPtr)vType.Payload.Handle;
 
             // Check the initial count
             Assert.Equal(1, Arc.RetainCount(payload.At(0)));
@@ -248,7 +248,7 @@ namespace BindingsGeneration.FunctionalTests
         {
             Bindings.NestedVType vType = new Bindings.NestedVType();
             GC.SuppressFinalize(vType);
-            IntPtr payload = (IntPtr)vType.Payload;
+            IntPtr payload = (IntPtr)vType.Payload.Handle;
 
             // Check the initial count
             Assert.Equal(1, Arc.RetainCount(payload.At(0)));
@@ -298,7 +298,7 @@ namespace BindingsGeneration.FunctionalTests
         {
             Bindings.NestedVType vType = new Bindings.NestedVType();
             GC.SuppressFinalize(vType);
-            IntPtr payload = (IntPtr)vType.Payload;
+            IntPtr payload = (IntPtr)vType.Payload.Handle;
 
             // Check the initial count
             Assert.Equal(1, Arc.RetainCount(payload.At(0)));
@@ -381,7 +381,7 @@ namespace BindingsGeneration.FunctionalTests
         {
             Bindings.NestedNestedVType vType = new Bindings.NestedNestedVType();
             GC.SuppressFinalize(vType);
-            IntPtr payload = (IntPtr)vType.Payload;
+            IntPtr payload = (IntPtr)vType.Payload.Handle;
 
             // Check the initial count
             Assert.Equal(1, Arc.RetainCount(payload.At(0)));
@@ -443,7 +443,7 @@ namespace BindingsGeneration.FunctionalTests
         {
             Bindings.NestedNestedVType vType = new Bindings.NestedNestedVType();
             GC.SuppressFinalize(vType);
-            IntPtr payload = (IntPtr)vType.Payload;
+            IntPtr payload = (IntPtr)vType.Payload.Handle;
 
             // Check the initial count
             Assert.Equal(1, Arc.RetainCount(payload.At(0)));
@@ -504,7 +504,7 @@ namespace BindingsGeneration.FunctionalTests
         {
             Bindings.NestedNestedVType vType = new Bindings.NestedNestedVType();
             GC.SuppressFinalize(vType);
-            IntPtr payload = (IntPtr)vType.Payload;
+            IntPtr payload = (IntPtr)vType.Payload.Handle;
 
             // Check the initial count
             Assert.Equal(1, Arc.RetainCount(payload.At(0)));
@@ -633,7 +633,7 @@ namespace BindingsGeneration.FunctionalTests
             Assert.Equal(1, Arc.RetainCount(payload));
 
             var nonfrozenHeapAllocated = new Bindings.NonFrozenStructHeapAllocated(42);
-            payload = nonfrozenHeapAllocated.Payload;
+            payload = nonfrozenHeapAllocated.Payload.Handle;
 
             // Check the initial count
             Assert.Equal(1, Arc.RetainCount(payload.At(0)));
@@ -682,25 +682,25 @@ namespace BindingsGeneration.FunctionalTests
             Assert.Equal(42, nonFrozenStructHeapAllocated.b);
 
             // Check the initial count
-            Assert.Equal(1, Arc.RetainCount(((IntPtr)nonFrozenStructHeapAllocated.Payload).At(0)));
+            Assert.Equal(1, Arc.RetainCount(((IntPtr)nonFrozenStructHeapAllocated.Payload.Handle).At(0)));
 
             var nonFrozenStructHeapAllocatedCopy = Bindings.MemoryTests.PassThroughNonFrozenStructHeapAllocated(nonFrozenStructHeapAllocated);
             // Check the payload
             Assert.Equal(42, nonFrozenStructHeapAllocatedCopy.b);
 
             // Check the references are not the same
-            Assert.NotEqual((IntPtr)nonFrozenStructHeapAllocated.Payload, (IntPtr)nonFrozenStructHeapAllocatedCopy.Payload);
+            Assert.NotEqual((IntPtr)nonFrozenStructHeapAllocated.Payload.Handle, (IntPtr)nonFrozenStructHeapAllocatedCopy.Payload.Handle);
 
             // Check the payloads are the same
-            Assert.Equal(((IntPtr)nonFrozenStructHeapAllocated.Payload).At(0), ((IntPtr)nonFrozenStructHeapAllocatedCopy.Payload).At(0));
+            Assert.Equal(((IntPtr)nonFrozenStructHeapAllocated.Payload.Handle).At(0), ((IntPtr)nonFrozenStructHeapAllocatedCopy.Payload.Handle).At(0));
 
             // Check the count after copy
-            Assert.Equal(2, Arc.RetainCount(((IntPtr)nonFrozenStructHeapAllocated.Payload).At(0)));
-            Assert.Equal(2, Arc.RetainCount(((IntPtr)nonFrozenStructHeapAllocatedCopy.Payload).At(0)));
+            Assert.Equal(2, Arc.RetainCount(((IntPtr)nonFrozenStructHeapAllocated.Payload.Handle).At(0)));
+            Assert.Equal(2, Arc.RetainCount(((IntPtr)nonFrozenStructHeapAllocatedCopy.Payload.Handle).At(0)));
         }
 
 
-        [Fact]
+        [Fact(Skip = "Change this test to test retain/release with dispose")]
         public unsafe void TestDisposeInvokesDestroyThreads()
         {
             var frozenHeapAllocated = new Bindings.FrozenStructHeapAllocated(42);
@@ -717,7 +717,7 @@ namespace BindingsGeneration.FunctionalTests
             Assert.Equal(2, Arc.RetainCount(payload));
 
             var nonfrozenHeapAllocated = new Bindings.NonFrozenStructHeapAllocated(42);
-            IntPtr nonfrozenPayload = nonfrozenHeapAllocated.Payload;
+            IntPtr nonfrozenPayload = nonfrozenHeapAllocated.Payload.Handle;
 
             // Check the initial count
             Assert.Equal(1, Arc.RetainCount(nonfrozenPayload.At(0)));

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Runtime/RuntimeTests.cs
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Runtime/RuntimeTests.cs
@@ -91,7 +91,7 @@ namespace BindingsGeneration.FunctionalTests
             Assert.Equal(3, Bindings.RuntimeTests.sumArray(array));
 
             // Check the initial count
-            var bufferPayload = array.Payload;
+            var bufferPayload = array.Payload.Handle;
             IntPtr payload = new IntPtr(&bufferPayload);
             Assert.Equal(1, Arc.RetainCount(payload.At(0)));
 
@@ -103,7 +103,7 @@ namespace BindingsGeneration.FunctionalTests
             Assert.Equal(3, Bindings.RuntimeTests.sumArray(arrayCopy));
 
             // Check the references are not the same
-            var bufferPayloadCopy = arrayCopy.Payload;
+            var bufferPayloadCopy = arrayCopy.Payload.Handle;
             IntPtr payloadCopy = new IntPtr(&bufferPayloadCopy);
             Assert.NotEqual(payload, payloadCopy);
 
@@ -131,7 +131,7 @@ namespace BindingsGeneration.FunctionalTests
             Assert.Equal(3, Bindings.RuntimeTests.sumArray(array));
 
             // Check the initial count
-            var bufferPayload = array.Payload;
+            var bufferPayload = array.Payload.Handle;
             IntPtr payload = new IntPtr(&bufferPayload);
             Assert.Equal(1, Arc.RetainCount(payload.At(0)));
 
@@ -143,7 +143,7 @@ namespace BindingsGeneration.FunctionalTests
             Assert.Equal(3, Bindings.RuntimeTests.sumArray(arrayCopy));
 
             // Check the count after the copy
-            var bufferPayloadCopy = arrayCopy.Payload;
+            var bufferPayloadCopy = arrayCopy.Payload.Handle;
             IntPtr payloadCopy = new IntPtr(&bufferPayloadCopy);
 
             Assert.Equal(2, Arc.RetainCount(payload.At(0)));
@@ -167,16 +167,16 @@ namespace BindingsGeneration.FunctionalTests
             Assert.Equal(arrayCopy[2], arrayCopyCopy[2]);
 
             // Check the count after the copy
-            Assert.Equal(1, Arc.RetainCount(array.Payload));
-            Assert.Equal(2, Arc.RetainCount(arrayCopy.Payload));
-            Assert.Equal(2, Arc.RetainCount(arrayCopyCopy.Payload));
+            Assert.Equal(1, Arc.RetainCount(array.Payload.Handle));
+            Assert.Equal(2, Arc.RetainCount(arrayCopy.Payload.Handle));
+            Assert.Equal(2, Arc.RetainCount(arrayCopyCopy.Payload.Handle));
 
             arrayCopy.Dispose();
 
             // Check the count after the copy is disposed
-            Assert.Equal(1, Arc.RetainCount(array.Payload));
-            Assert.Equal(1, Arc.RetainCount(arrayCopy.Payload));
-            Assert.Equal(1, Arc.RetainCount(arrayCopyCopy.Payload));
+            Assert.Equal(1, Arc.RetainCount(array.Payload.Handle));
+            Assert.Equal(1, Arc.RetainCount(arrayCopy.Payload.Handle));
+            Assert.Equal(1, Arc.RetainCount(arrayCopyCopy.Payload.Handle));
         }
 
         [Fact]
@@ -220,7 +220,7 @@ namespace BindingsGeneration.FunctionalTests
             Assert.Equal(3, SumSet(set));
 
             // Check the initial count
-            var bufferPayload = set.Payload;
+            var bufferPayload = set.Payload.Handle;
             var payload = (IntPtr*)&bufferPayload;
             Assert.Equal(1, Arc.RetainCount(*payload));
 
@@ -229,7 +229,7 @@ namespace BindingsGeneration.FunctionalTests
             Assert.Equal(3, SumSet(setCopy));
 
             // Check the references are not the same
-            var bufferPayloadCopy = setCopy.Payload;
+            var bufferPayloadCopy = setCopy.Payload.Handle;
             var payloadCopy = (IntPtr*)&bufferPayloadCopy;
             Assert.NotEqual((IntPtr)payload, (IntPtr)payloadCopy);
 
@@ -249,34 +249,34 @@ namespace BindingsGeneration.FunctionalTests
         // TODO: Remove helper methods when https://github.com/dotnet/runtimelab/issues/2970
         private static unsafe SwiftSet<SwiftIntMock> GetSet(int count)
         {
-            SwiftHandle variant = PInvoke_GetSet(count);
-            return SwiftMarshal.MarshalFromSwift<SwiftSet<SwiftIntMock>>((SwiftHandle)new IntPtr(&variant));
+            IntPtr variant = PInvoke_GetSet(count);
+            return SwiftMarshal.MarshalFromSwift<SwiftSet<SwiftIntMock>>(variant);
         }
 
         private static unsafe int SumSet(SwiftSet<SwiftIntMock> set)
         {
-            SwiftHandle variant = set.Payload;
+            IntPtr variant = set.Payload.Handle;
             return PInvoke_SumSet(variant);
         }
 
         private static unsafe SwiftSet<SwiftIntMock> PassThroughSet(SwiftSet<SwiftIntMock> set)
         {
-            SwiftHandle variant = set.Payload;
+            IntPtr variant = set.Payload.Handle;
             variant = PInvoke_PassThroughSet(variant);
-            return SwiftMarshal.MarshalFromSwift<SwiftSet<SwiftIntMock>>((SwiftHandle)new IntPtr(&variant));
+            return SwiftMarshal.MarshalFromSwift<SwiftSet<SwiftIntMock>>(variant);
         }
 
         [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSwift) })]
         [DllImport("Runtime/libRuntimeTests.dylib", EntryPoint = "$s12RuntimeTests8getArray5countSays5Int32VGAE_tF")]
-        private static extern SwiftHandle PInvoke_GetSet(int count);
+        private static extern IntPtr PInvoke_GetSet(int count);
 
         [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSwift) })]
         [DllImport("Runtime/libRuntimeTests.dylib", EntryPoint = "$s12RuntimeTests8sumArray5arrays5Int32VSayAEG_tF")]
-        private static extern int PInvoke_SumSet(SwiftHandle set);
+        private static extern int PInvoke_SumSet(IntPtr set);
 
         [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSwift) })]
         [DllImport("Runtime/libRuntimeTests.dylib", EntryPoint = "$s12RuntimeTests16passThroughArray5arraySays5Int32VGAF_tF")]
-        private static extern SwiftHandle PInvoke_PassThroughSet(SwiftHandle set);
+        private static extern IntPtr PInvoke_PassThroughSet(IntPtr set);
 
         [Fact]
         public void SmokeTestString()

--- a/src/Swift.Runtime/src/Swift/AnyType.cs
+++ b/src/Swift.Runtime/src/Swift/AnyType.cs
@@ -49,7 +49,7 @@ public struct AnyType : ISwiftObject
         }
         unsafe
         {
-            metadata.ValueWitnessTable->InitializeWithCopy((void*)swiftDest, (void*)_payload, metadata);
+            metadata.ValueWitnessTable->InitializeWithCopy((void*)swiftDest, (void*)_payload.Handle, metadata);
         }
         return swiftDest;
     }

--- a/src/Swift.Runtime/src/Swift/Data.cs
+++ b/src/Swift.Runtime/src/Swift/Data.cs
@@ -87,7 +87,8 @@ public struct Data : ISwiftObject
     /// </summary>
     unsafe Data(SwiftHandle handle)
     {
-        this = *(Data*)handle;
+        this = *(Data*)handle.Handle;
+        // TODO: Add SwiftHandle field
     }
 
     /// <summary>

--- a/src/Swift.Runtime/src/Swift/Runtime/InteropServices/SwiftMarshal.cs
+++ b/src/Swift.Runtime/src/Swift/Runtime/InteropServices/SwiftMarshal.cs
@@ -131,7 +131,7 @@ public static class SwiftMarshal
     /// <param name="swiftSource">Memory to read from</param>
     /// <returns>The C# type created by marshaling</returns>
     /// <exception cref="NotSupportedException"></exception>
-    public static T MarshalFromSwift<T>(SwiftHandle swiftSource)
+    public static T MarshalFromSwift<T>(IntPtr swiftSource)
     {
         if (typeof(ISwiftObject).IsAssignableFrom(typeof(T)))
         {

--- a/src/Swift.Runtime/src/Swift/Runtime/SwiftHandle.cs
+++ b/src/Swift.Runtime/src/Swift/Runtime/SwiftHandle.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection.Metadata;
+using Microsoft.Win32.SafeHandles;
 
 #nullable enable
 
@@ -11,137 +13,52 @@ namespace Swift.Runtime;
 /// <summary>
 /// Represents an opaque handle to a Swift object
 /// </summary>
-public readonly struct SwiftHandle : IEquatable<SwiftHandle>
+public sealed class SwiftHandle : SafeHandleZeroOrMinusOneIsInvalid
 {
-    readonly IntPtr handle;
-
-    public IntPtr Handle => handle;
+    private TypeMetadata _metadata = default;
+    public TypeMetadata Metadata => _metadata;
 
     /// <summary>
     /// Returns an SwiftHandle with a zero value
     /// </summary>
-    public readonly static SwiftHandle Zero = default(SwiftHandle);
+    public readonly static SwiftHandle Zero = new SwiftHandle(IntPtr.Zero);
+
+// get set
+    public IntPtr Handle
+    {
+        get => handle;
+        set => SetHandle(value);
+    }
 
     /// <summary>
     /// Constructs a SwiftHandle from the given IntPtr
     /// </summary>
     public SwiftHandle(IntPtr handle)
+        : base(ownsHandle: true)
     {
-        this.handle = handle;
+        SetHandle(handle);
     }
 
-    /// <summary>
-    /// Returns true if the SwiftHandle and the IntPtr are the same
-    /// </summary>
-    public static bool operator ==(SwiftHandle left, IntPtr right)
+    protected override unsafe bool ReleaseHandle()
     {
-        return left.handle == right;
+        // _metadata.ValueWitnessTable->Destroy((void*)handle, _metadata);
+        return true;
     }
 
-    /// <summary>
-    /// Returns true if both SwiftHandles are the same
-    /// </summary>
-    public static bool operator ==(SwiftHandle left, SwiftHandle right)
-    {
-        return left.handle == right.handle;
-    }
+    // /// <summary>
+    // /// Implicit conversion from SwiftHandle to IntPtr
+    // /// </summary>
+    // public static implicit operator IntPtr(SwiftHandle value)
+    // {
+    //     return value.handle;
+    // }
 
-    /// <summary>
-    /// Returns true if the IntPtr and the SwiftHandle are the same
-    /// </summary>
-    public static bool operator ==(IntPtr left, SwiftHandle right)
-    {
-        return left == right.Handle;
-    }
+    // /// <summary>
+    // /// Explicit conversion from SwiftHandle to void*
+    // /// </summary>
+    // public unsafe static explicit operator void*(SwiftHandle value)
+    // {
+    //     return (void*)value.handle;
+    // }
 
-    /// <summary>
-    /// Returns true if the SwiftHandle and the IntPtr are different
-    /// </summary>
-    public static bool operator !=(SwiftHandle left, IntPtr right)
-    {
-        return left.handle != right;
-    }
-
-    /// <summary>
-    /// Returns true if the IntPtr and the SwiftHandle are different
-    /// </summary>
-    public static bool operator !=(IntPtr left, SwiftHandle right)
-    {
-        return left != right.Handle;
-    }
-
-    /// <summary>
-    /// Returns true if the SwiftHandles are different
-    /// </summary>
-    public static bool operator !=(SwiftHandle left, SwiftHandle right)
-    {
-        return left.handle != right.Handle;
-    }
-
-
-    /// <summary>
-    /// Implicit conversion from SwiftHandle to IntPtr
-    /// </summary>
-    public static implicit operator IntPtr(SwiftHandle value)
-    {
-        return value.Handle;
-    }
-
-    /// <summary>
-    /// Explicit conversion from IntPtr to SwiftHandle
-    /// </summary>
-    public static explicit operator SwiftHandle(IntPtr value)
-    {
-        return new SwiftHandle(value);
-    }
-
-    /// <summary>
-    /// Explicit conversion from SwiftHandle to void*
-    /// </summary>
-    public unsafe static explicit operator void*(SwiftHandle value)
-    {
-        return (void*)(IntPtr)value;
-    }
-
-    /// <summary>
-    /// Explicit conversion from void* to SwiftHandle
-    /// </summary>
-    public unsafe static explicit operator SwiftHandle(void* value)
-    {
-        return new SwiftHandle((IntPtr)value);
-    }
-
-    /// <summary>
-    /// Compare this SwiftHandle to the given object, returns true if they're the same.
-    /// </summary>
-    public override bool Equals(object? o)
-    {
-        if (o is SwiftHandle nh)
-            return nh.handle == this.handle;
-        return false;
-    }
-
-    /// <summary>
-    /// Generate a hashcode for the SwiftHandle
-    /// </summary>
-    public override int GetHashCode()
-    {
-        return handle.GetHashCode();
-    }
-
-    /// <summary>
-    /// Returns true if this matches the give SwiftHandle
-    /// </summary>
-    public bool Equals(SwiftHandle other)
-    {
-        return other.handle == handle;
-    }
-
-    /// <summary>
-    /// Generates a string representation of this SwiftHandle
-    /// </summary>
-    public override string ToString()
-    {
-        return "0x" + handle.ToString("x");
-    }
 }

--- a/src/Swift.Runtime/src/Swift/SwiftArray.cs
+++ b/src/Swift.Runtime/src/Swift/SwiftArray.cs
@@ -55,10 +55,8 @@ public class SwiftArray<Element> : IDisposable, ISwiftObject
 
             unsafe
             {
-                fixed (void* payload = &_buffer)
-                {
-                    metadata.ValueWitnessTable->Destroy(payload, metadata);
-                }
+                var handle = _buffer.Handle;
+                metadata.ValueWitnessTable->Destroy(&handle, metadata);
             }
             _disposed = true;
         }
@@ -95,10 +93,8 @@ public class SwiftArray<Element> : IDisposable, ISwiftObject
         var metadata = SwiftObjectHelper<SwiftArray<Element>>.GetTypeMetadata();
         unsafe
         {
-            fixed (void* _payloadPtr = &_buffer)
-            {
-                metadata.ValueWitnessTable->InitializeWithCopy((void*)swiftDest, (void*)_payloadPtr, metadata);
-            }
+            IntPtr handle = _buffer.Handle;
+            metadata.ValueWitnessTable->InitializeWithCopy((void*)swiftDest, &handle, metadata);
         }
         return swiftDest;
     }
@@ -123,7 +119,7 @@ public class SwiftArray<Element> : IDisposable, ISwiftObject
     /// </summary>
     unsafe SwiftArray(SwiftHandle handle)
     {
-        _buffer = *(SwiftHandle*)handle;
+        _buffer = handle;
     }
 
     /// <summary>
@@ -131,7 +127,8 @@ public class SwiftArray<Element> : IDisposable, ISwiftObject
     /// </summary>
     public SwiftArray()
     {
-        _buffer = SwiftArrayPInvokes.Init(ElementTypeMetadata);
+        IntPtr handle = SwiftArrayPInvokes.Init(ElementTypeMetadata);
+        _buffer = new SwiftHandle(handle);
     }
 
     /// <summary>
@@ -141,7 +138,7 @@ public class SwiftArray<Element> : IDisposable, ISwiftObject
     {
         get
         {
-            return (int)SwiftArrayPInvokes.Count(_buffer, ElementTypeMetadata);
+            return (int)SwiftArrayPInvokes.Count(_buffer.Handle, ElementTypeMetadata);
         }
     }
 
@@ -156,11 +153,9 @@ public class SwiftArray<Element> : IDisposable, ISwiftObject
         {
             payload = (IntPtr)NativeMemory.Alloc(ElementSize);
             SwiftMarshal.MarshalToSwift(item, payload);
-
-            fixed (void* bufferPtr = &_buffer)
-            {
-                SwiftArrayPInvokes.Append(payload, metadata, new SwiftSelf(bufferPtr));
-            }
+            IntPtr handle = _buffer.Handle;
+            SwiftArrayPInvokes.Append(payload, metadata, new SwiftSelf((void*)&handle));
+            _buffer.Handle = handle;
         }
         finally
         {
@@ -173,21 +168,12 @@ public class SwiftArray<Element> : IDisposable, ISwiftObject
     /// </summary>
     public unsafe void Insert(int index, Element item)
     {
-        IntPtr payload = IntPtr.Zero;
         var metadata = SwiftObjectHelper<SwiftArray<Element>>.GetTypeMetadata();
-        try
-        {
-            payload = (IntPtr)NativeMemory.Alloc(ElementSize);
-            SwiftMarshal.MarshalToSwift(item, payload);
-            fixed (void* bufferPtr = &_buffer)
-            {
-                SwiftArrayPInvokes.Insert(new SwiftHandle(payload), (nint)index, metadata, new SwiftSelf(bufferPtr));
-            }
-        }
-        finally
-        {
-            NativeMemory.Free((void*)payload);
-        }
+        byte* payload = stackalloc byte[(int)ElementSize];
+        SwiftMarshal.MarshalToSwift(item, (IntPtr)payload);
+        IntPtr handle = _buffer.Handle;
+        SwiftArrayPInvokes.Insert((IntPtr)payload, index, metadata, new SwiftSelf(&handle));
+        _buffer.Handle = handle;
     }
 
     /// <summary>
@@ -195,22 +181,13 @@ public class SwiftArray<Element> : IDisposable, ISwiftObject
     /// </summary>
     public unsafe void Remove(int index)
     {
-        IntPtr payload = IntPtr.Zero;
         var metadata = SwiftObjectHelper<SwiftArray<Element>>.GetTypeMetadata();
-        try
-        {
-            payload = (IntPtr)NativeMemory.Alloc(ElementSize);
-            SwiftMarshal.MarshalToSwift(index, payload);
+        byte* payload = stackalloc byte[(int)ElementSize];
+        SwiftMarshal.MarshalToSwift(index, (IntPtr)payload);
 
-            fixed (void* bufferPtr = &_buffer)
-            {
-                SwiftArrayPInvokes.Remove(new SwiftIndirectResult((void*)payload), (nint)index, metadata, new SwiftSelf(bufferPtr));
-            }
-        }
-        finally
-        {
-            NativeMemory.Free((void*)payload);
-        }
+        IntPtr handle = _buffer.Handle;
+        SwiftArrayPInvokes.Remove(new SwiftIndirectResult(payload), index, metadata, new SwiftSelf(&handle));
+        _buffer.Handle = handle;
     }
 
     /// <summary>
@@ -219,11 +196,9 @@ public class SwiftArray<Element> : IDisposable, ISwiftObject
     public unsafe void RemoveAll()
     {
         var metadata = SwiftObjectHelper<SwiftArray<Element>>.GetTypeMetadata();
-
-        fixed (void* bufferPtr = &_buffer)
-        {
-            SwiftArrayPInvokes.RemoveAll(1, metadata, new SwiftSelf(bufferPtr));
-        }
+        IntPtr handle = _buffer.Handle;
+        SwiftArrayPInvokes.RemoveAll(1, metadata, new SwiftSelf(&handle));
+        _buffer.Handle = handle;
     }
 
     /// <summary>
@@ -237,8 +212,8 @@ public class SwiftArray<Element> : IDisposable, ISwiftObject
                 throw new IndexOutOfRangeException();
 
             IntPtr payload = (IntPtr)NativeMemory.Alloc(ElementSize);
-            SwiftArrayPInvokes.Get(new SwiftIndirectResult((void*)payload), (nint)index, _buffer, ElementTypeMetadata);
-            return SwiftMarshal.MarshalFromSwift<Element>(new SwiftHandle(payload));
+            SwiftArrayPInvokes.Get(new SwiftIndirectResult((void*)payload), (nint)index, _buffer.Handle, ElementTypeMetadata);
+            return SwiftMarshal.MarshalFromSwift<Element>(payload);
         }
         set
         {
@@ -249,10 +224,9 @@ public class SwiftArray<Element> : IDisposable, ISwiftObject
             IntPtr payload = (IntPtr)NativeMemory.Alloc(ElementSize);
             SwiftMarshal.MarshalToSwift(value, payload);
 
-            fixed (void* bufferPtr = &_buffer)
-            {
-                SwiftArrayPInvokes.Set(new SwiftHandle(payload), (nint)index, metadata, new SwiftSelf(bufferPtr));
-            }
+            IntPtr handle = _buffer.Handle;
+            SwiftArrayPInvokes.Set(payload, index, metadata, new SwiftSelf(&handle));
+            _buffer.Handle = handle;
         }
     }
 }
@@ -265,19 +239,19 @@ internal static class SwiftArrayPInvokes
 
     [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
     [DllImport(KnownLibraries.SwiftCore, EntryPoint = "$sS2ayxGycfC")]
-    public static extern SwiftHandle Init(TypeMetadata typeMetadata);
+    public static extern IntPtr Init(TypeMetadata typeMetadata);
 
     [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
     [DllImport(KnownLibraries.SwiftCore, EntryPoint = "$sSayxSicig")]
-    public static unsafe extern void Get(SwiftIndirectResult result, nint index, SwiftHandle handle, TypeMetadata elementMetadata);
+    public static unsafe extern void Get(SwiftIndirectResult result, nint index, IntPtr handle, TypeMetadata elementMetadata);
 
     [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
     [DllImport(KnownLibraries.SwiftCore, EntryPoint = "$sSayxSicis")]
-    public static unsafe extern void Set(SwiftHandle value, nint index, TypeMetadata elementMetadata, SwiftSelf self);
+    public static unsafe extern void Set(IntPtr value, nint index, TypeMetadata elementMetadata, SwiftSelf self);
 
     [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
     [DllImport(KnownLibraries.SwiftCore, EntryPoint = "$sSa5countSivg")]
-    public static extern nint Count(SwiftHandle handle, TypeMetadata elementMetadata);
+    public static extern nint Count(IntPtr handle, TypeMetadata elementMetadata);
 
     [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
     [DllImport(KnownLibraries.SwiftCore, EntryPoint = "$sSa6appendyyxnF")]
@@ -293,5 +267,5 @@ internal static class SwiftArrayPInvokes
 
     [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
     [DllImport(KnownLibraries.SwiftCore, EntryPoint = "$sSa6insert_2atyxn_SitF")]
-    public static unsafe extern void Insert(SwiftHandle value, nint index, TypeMetadata metadata, SwiftSelf self);
+    public static unsafe extern void Insert(IntPtr value, nint index, TypeMetadata metadata, SwiftSelf self);
 }

--- a/src/Swift.Runtime/src/Swift/SwiftOptional.cs
+++ b/src/Swift.Runtime/src/Swift/SwiftOptional.cs
@@ -52,7 +52,7 @@ public class SwiftOptional<T> : ISwiftObject
         {
             fixed (byte* payloadPtr = instance._payload)
             {
-                metadata.ValueWitnessTable->InitializeWithCopy(payloadPtr, (byte*)payload, metadata);
+                metadata.ValueWitnessTable->InitializeWithCopy(payloadPtr, (byte*)payload.Handle, metadata);
                 return instance;
             }
         }
@@ -159,8 +159,7 @@ public class SwiftOptional<T> : ISwiftObject
                 _payload.CopyTo(payload);
                 fixed (byte* payloadPtr = payload)
                 {
-                    metadata.ValueWitnessTable->DestructiveProjectEnumData(payloadPtr, metadata);
-                    return SwiftMarshal.MarshalFromSwift<T>((SwiftHandle)new IntPtr(payloadPtr));
+                    return SwiftMarshal.MarshalFromSwift<T>(new IntPtr(payloadPtr));
                 }
             }
         }

--- a/src/Swift.Runtime/src/Swift/SwiftSet.cs
+++ b/src/Swift.Runtime/src/Swift/SwiftSet.cs
@@ -55,10 +55,8 @@ public class SwiftSet<Element> : IDisposable, ISwiftObject
 
             unsafe
             {
-                fixed (void* payload = &_variant)
-                {
-                    metadata.ValueWitnessTable->Destroy(payload, metadata);
-                }
+                var handle = _variant.Handle;
+                metadata.ValueWitnessTable->Destroy(&handle, metadata);
             }
             _disposed = true;
         }
@@ -96,10 +94,8 @@ public class SwiftSet<Element> : IDisposable, ISwiftObject
         var metadata = SwiftObjectHelper<SwiftSet<Element>>.GetTypeMetadata();
         unsafe
         {
-            fixed (void* _payloadPtr = &_variant)
-            {
-                metadata.ValueWitnessTable->InitializeWithCopy((void*)swiftDest, (void*)_payloadPtr, metadata);
-            }
+            IntPtr handle = _variant.Handle;
+            metadata.ValueWitnessTable->InitializeWithCopy((void*)swiftDest, &handle, metadata);
         }
         return swiftDest;
     }
@@ -124,7 +120,7 @@ public class SwiftSet<Element> : IDisposable, ISwiftObject
     /// </summary>
     unsafe SwiftSet(SwiftHandle handle)
     {
-        _variant = *(SwiftHandle*)handle;
+        _variant = handle;
     }
 
     /// <summary>
@@ -133,7 +129,8 @@ public class SwiftSet<Element> : IDisposable, ISwiftObject
     public SwiftSet()
     {
         var witnessTable = ProtocolWitnessTable.GetOrThrow<Element, ISwiftHashable>();
-        _variant = SwiftSetPInvokes.Init(ElementTypeMetadata, witnessTable);
+        IntPtr handle = SwiftSetPInvokes.Init(ElementTypeMetadata, witnessTable);
+        _variant = new SwiftHandle(handle);
     }
 
     /// <summary>
@@ -144,7 +141,7 @@ public class SwiftSet<Element> : IDisposable, ISwiftObject
         get
         {
             var witnessTable = ProtocolWitnessTable.GetOrThrow<Element, ISwiftHashable>();
-            return (int)SwiftSetPInvokes.Count(_variant, ElementTypeMetadata, witnessTable);
+            return (int)SwiftSetPInvokes.Count(_variant.Handle, ElementTypeMetadata, witnessTable);
         }
     }
 }
@@ -157,9 +154,9 @@ internal static class SwiftSetPInvokes
 
     [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
     [DllImport(KnownLibraries.SwiftCore, EntryPoint = "$sS2hyxGycfC")]
-    public static extern SwiftHandle Init(TypeMetadata elementTypeMetadata, ProtocolWitnessTable witnessTable);
+    public static extern IntPtr Init(TypeMetadata elementTypeMetadata, ProtocolWitnessTable witnessTable);
 
     [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
     [DllImport(KnownLibraries.SwiftCore, EntryPoint = "$sSh5countSivg")]
-    public static extern nint Count(SwiftHandle handle, TypeMetadata elementMetadata, ProtocolWitnessTable witnessTable);
+    public static extern nint Count(IntPtr handle, TypeMetadata elementMetadata, ProtocolWitnessTable witnessTable);
 }

--- a/src/Swift.Runtime/src/Swift/SwiftString.cs
+++ b/src/Swift.Runtime/src/Swift/SwiftString.cs
@@ -111,7 +111,7 @@ public class SwiftString : IDisposable, ISwiftObject
     /// </summary>
     unsafe SwiftString(SwiftHandle handle)
     {
-        _payload = *(Buffer*)handle;
+        _payload = *(Buffer*)handle.Handle;
     }
 
     /// <summary>

--- a/src/Swift.Runtime/tests/LibraryTests/SwiftArrayTests.cs
+++ b/src/Swift.Runtime/tests/LibraryTests/SwiftArrayTests.cs
@@ -128,12 +128,12 @@ public class SwiftArrayTests : IClassFixture<SwiftArrayTests.TestFixture>
         Assert.Equal(0, array.Count);
         // An empty array is singleton and it's count doesn't change with new instances
         // https://github.com/swiftlang/swift/blob/50a98d3055e5a636d80c376a99b4eea35387cd0d/stdlib/public/SwiftShims/swift/shims/GlobalObjects.h#L44
-        Assert.True(Arc.RetainCount(array.Payload) > 1);
+        Assert.True(Arc.RetainCount(array.Payload.Handle) > 1);
 
         array.Append(42);
         Assert.Equal(1, array.Count);
         // A new buffer is created, ref count is 1
-        Assert.Equal(1, Arc.RetainCount(array.Payload));
+        Assert.Equal(1, Arc.RetainCount(array.Payload.Handle));
     }
 
     private void PrimitiveArrayTest<T>(T value1, T value2, T overwriteValue)

--- a/src/Swift.Runtime/tests/LibraryTests/SwiftSetTests.cs
+++ b/src/Swift.Runtime/tests/LibraryTests/SwiftSetTests.cs
@@ -47,6 +47,6 @@ public class SwiftSetTests : IClassFixture<SwiftSetTests.TestFixture>
         Assert.Equal(0, set.Count);
         // An empty array is singleton and it's count doesn't change with new instances
         // https://github.com/swiftlang/swift/blob/50a98d3055e5a636d80c376a99b4eea35387cd0d/stdlib/public/SwiftShims/swift/shims/GlobalObjects.h#L44
-        Assert.True(Arc.RetainCount(set.Payload) > 1);
+        Assert.True(Arc.RetainCount(set.Payload.Handle) > 1);
     }
 }


### PR DESCRIPTION
## Description

To ensure thread safety and delegate handle release to the native handler, `SwiftHandle` implements `SafeHandle` for a native Swift handle. When the handle is released, it calls `ValueWitnessTable->Destroy` function to free native resources:
```swift
public sealed class SwiftHandle : SafeHandleZeroOrMinusOneIsInvalid
{
    private TypeMetadata _metadata = default;
    public TypeMetadata Metadata
    {
        get => _metadata;
        set => _metadata = value;
    }

    public IntPtr Handle
    {
        get => handle;
        set => SetHandle(value);
    }

    public SwiftHandle(IntPtr handle)
        : base(ownsHandle: true)
    {
        SetHandle(handle);
    }

    protected override unsafe bool ReleaseHandle()
    {
        _metadata.ValueWitnessTable->Destroy((void*)handle, _metadata);
        return true;
    }
}
```
The .NET runtime automatically handles the reference counting of SwiftHandle at the P/Invoke boundary. However, due to the lowering algorithm in `SwiftCallConv`, a raw pointer is passed instead, and the safe handle’s reference counting must be handled manually to prevent premature cleanup during P/Invoke calls:
```csharp
_payload.DangerousAddRef(out bool result);
PInvoke_call(payload.Handle);
_payload.DangerousRelease();
```

Non-frozen structs projected as C# classes do not require explicit `Dispose` methods or finalizers, since the GC calls `Dispose` of the `SafeHandle` when the object is collected. For frozen structs that require manual memory management, a `Buffer` struct is passed at the P/Invoke boundary, while a corresponding `SwiftHandle` handles reference counting for that buffer.

## Tasks
- [ ] Implement `SwiftHandle` as `SafeHandle`
- [ ] Implement manual reference counting via `DangerousAddRef` and `DangerousRelease` around P/Invoke calls
- [ ] Update `MarshalToSwift` and `MarshalFromSwift` to reflect `SwiftHandle` implementation 
- [ ] Ensure `SwiftHandle` release resources by calling `_metadata.ValueWitnessTable->Destroy` only after all references are released
- [ ] Remove `IDisposable` and finalizer from C# classes
- [ ] Update manual bindings to reflect `SwiftHandle` implementation 
- [ ] Update CryptoKit bindings to reflect `SwiftHandle` implementation

Fixes https://github.com/dotnet/runtimelab/issues/3018 https://github.com/dotnet/runtimelab/issues/2975
